### PR TITLE
Increased minimum Ansible version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - MOLECULEW_USE_SYSTEM=true
   matrix:
     # Spin off separate builds for each of the following versions of Ansible
-    - MOLECULEW_ANSIBLE=2.6.18
+    - MOLECULEW_ANSIBLE=2.7.15
     - MOLECULEW_ANSIBLE=2.9.1
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ users home directory.
 Requirements
 ------------
 
-* Ansible >= 2.6
+* Ansible >= 2.7
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Role for backing up and restoring files and directories.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.7
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.7.